### PR TITLE
fix-print-version-issue

### DIFF
--- a/lode_runner/core.py
+++ b/lode_runner/core.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+import os
+import sys
 import logging
 from unittest import suite
 
@@ -116,6 +118,21 @@ class LodeRunner(TextTestRunner):
 
 
 class LodeProgram(TestProgram):
+    def parseArgs(self, argv):
+        """Parse argv and env and configure running environment.
+        """
+        self.config.configure(argv, doc=self.usage())
+        log.debug("configured %s", self.config)
+
+        if self.config.options.version:
+            import pkg_resources
+            version = pkg_resources.get_distribution("lode_runner").version
+            sys.stdout = sys.__stdout__
+            print("%s version %s" % (os.path.basename(sys.argv[0]), version))
+            sys.exit(0)
+
+        return super(LodeProgram, self).parseArgs(argv)
+
     def runTests(self):
         from lode_runner.plugins import multiprocess
         multiprocess._instantiate_plugins = [

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 setup(
     name='lode_runner',
     url='https://github.com/2gis/lode_runner',
-    version='0.4.6',
+    version='0.4.7',
     description='Nosetests runner plugins package',
     long_description='',
     author='Igor Pavlov',


### PR DESCRIPTION
`--version` now returns actual lode_runner version

https://github.com/2gis/lode_runner/issues/29